### PR TITLE
Fix CVModel creation in TopicMembershipModel

### DIFF
--- a/adatest/_topic_model.py
+++ b/adatest/_topic_model.py
@@ -157,8 +157,7 @@ class TopicMembershipModel:
         else:
             
             # we are in a highly overparametrized situation, so we use a linear SVC to get "max-margin" based generalization
-            self.model = CVModel()
-            self.model.fit(embeddings, labels)
+            self.model = CVModel(embeddings, labels)
 
     def __call__(self, input):
         embeddings = adatest.embed([input])[0]


### PR DESCRIPTION
This is causing adatest to occasionally throw
```
TypeError: CVModel.__init__() missing 2 required positional arguments: 'embeddings' and 'labels'
```

Removed the `fit` call because it happens internally in the `__init__`.

See constructor here: https://github.com/microsoft/adatest/blob/a77b5968dca69480aaf11af9a326bafab7c345a8/adatest/_topic_model.py#L21

And another `CVModel` usage here: https://github.com/microsoft/adatest/blob/a77b5968dca69480aaf11af9a326bafab7c345a8/adatest/_topic_model.py#L93