### PR TITLE
Fix CVModel in TopicMembershipModel

### DIFF
--- a/adatest/_topic_model.py
+++ b/adatest/_topic_model.py
@@ -157,8 +157,7 @@ class TopicMembershipModel:
         else:
             
             # we are in a highly overparametrized situation, so we use a linear SVC to get "max-margin" based generalization
-            self.model = CVModel()
-            self.model.fit(embeddings, labels)
+            self.model = CVModel(embeddings, labels)
 
     def __call__(self, input):
         embeddings = adatest.embed([input])[0]

--- a/adatest/_topic_model.py
+++ b/adatest/_topic_model.py
@@ -19,7 +19,8 @@ class ConstantModel():
 
 class CVModel():
     def __init__(self, embeddings, labels):
-        self.inner_model = RidgeClassifierCV(class_weight={"pass": 1, "fail": 1})
+        class_weight = {label: 1 for label in labels}
+        self.inner_model = RidgeClassifierCV(class_weight=class_weight)
         self.inner_model.fit(embeddings, labels)
 
     def predict_prob(self, embeddings):


### PR DESCRIPTION
This is causing adatest to throw errors when generating topics:
```
TypeError: CVModel.__init__() missing 2 required positional arguments: 'embeddings' and 'labels'
```

Removed the `fit` call because it happens internally in the `__init__`.

Also fixed the init to set `class_weight` to 1 for the passed in labels, instead of assuming labels are "pass" / "fail" (for `TopicMembershipModel` they are "on_topic" / "off_topic") - I think class_weight = 1 is [the default behavior](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.RidgeClassifierCV.html), but will keep for consistency

Now matches the other `CVModel` usage here: https://github.com/microsoft/adatest/blob/a77b5968dca69480aaf11af9a326bafab7c345a8/adatest/_topic_model.py#L93